### PR TITLE
Implement additional info box

### DIFF
--- a/index.html
+++ b/index.html
@@ -445,6 +445,10 @@
                                         <div class="info-grid" id="extracted-info-grid">
                                             <!-- 动态生成的提取信息 -->
                                         </div>
+                                        <div class="additional-info" id="additional-info-container" style="display:none;">
+                                            <label for="additional-info">附加信息</label>
+                                            <textarea id="additional-info" rows="4"></textarea>
+                                        </div>
                                         
                                         <div class="confirmation-actions">
                                             <button class="btn btn-secondary" onclick="backToStep(1)">

--- a/script.js
+++ b/script.js
@@ -1144,14 +1144,39 @@ function switchGenerationStep(stepNumber) {
 
 function fillExtractedInfo(info) {
     const container = document.getElementById('extracted-info-grid');
-    if (!container) return;
-    
-    container.innerHTML = Object.entries(info).map(([key, value]) => `
+    const extraContainer = document.getElementById('additional-info-container');
+    const extraInput = document.getElementById('additional-info');
+    if (!container || !extraInput || !extraContainer) return;
+
+    // 拆分前三项与其余信息
+    const entries = Object.entries(info).filter(([k]) => k !== 'speculated' && k !== '_speculated');
+    const mainEntries = entries.slice(0, 3);
+    const extraEntries = entries.slice(3);
+
+    // 渲染前三项
+    container.innerHTML = mainEntries.map(([key, value]) => `
         <div class="info-item">
             <label>${formatFieldName(key)}:</label>
             <input type="text" value="${escapeHtml(value)}" data-field="${key}">
         </div>
     `).join('');
+
+    // 处理附加信息
+    if (extraEntries.length) {
+        extraContainer.style.display = 'block';
+        extraInput.value = extraEntries.map(([k, v]) => `${formatFieldName(k)}: ${v}`).join('\n');
+    } else {
+        extraContainer.style.display = 'none';
+        extraInput.value = '';
+    }
+
+    // 根据推测标记显示颜色
+    const speculated = info.speculated || info._speculated;
+    if (speculated) {
+        extraInput.classList.add('speculated');
+    } else {
+        extraInput.classList.remove('speculated');
+    }
 }
 
 function formatFieldName(fieldName) {
@@ -1434,17 +1459,38 @@ window.backToStep = function(stepNumber) {
 // 填充提取的信息到确认界面
 function fillExtractedInfo(info) {
     const container = document.getElementById('extracted-info-grid');
-    if (!container) {
-        console.error('找不到 extracted-info-grid 元素');
+    const extraContainer = document.getElementById('additional-info-container');
+    const extraInput = document.getElementById('additional-info');
+    if (!container || !extraInput || !extraContainer) {
+        console.error('找不到信息展示区域');
         return;
     }
-    
-    container.innerHTML = Object.entries(info).map(([key, value]) => `
+
+    const entries = Object.entries(info).filter(([k]) => k !== 'speculated' && k !== '_speculated');
+    const mainEntries = entries.slice(0, 3);
+    const extraEntries = entries.slice(3);
+
+    container.innerHTML = mainEntries.map(([key, value]) => `
         <div class="info-item">
             <label for="field-${key}">${formatFieldName(key)}</label>
             <input type="text" id="field-${key}" value="${escapeHtml(value)}" data-field="${key}">
         </div>
     `).join('');
+
+    if (extraEntries.length) {
+        extraContainer.style.display = 'block';
+        extraInput.value = extraEntries.map(([k, v]) => `${formatFieldName(k)}: ${v}`).join('\n');
+    } else {
+        extraContainer.style.display = 'none';
+        extraInput.value = '';
+    }
+
+    const speculated = info.speculated || info._speculated;
+    if (speculated) {
+        extraInput.classList.add('speculated');
+    } else {
+        extraInput.classList.remove('speculated');
+    }
 }
 
 // 格式化字段名称

--- a/style.css
+++ b/style.css
@@ -1581,6 +1581,26 @@ body {
     box-shadow: 0 0 0 3px rgba(74, 108, 247, 0.1);
 }
 
+.additional-info {
+    margin-top: var(--spacing-md);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+}
+
+.additional-info textarea {
+    width: 100%;
+    padding: var(--spacing-sm) var(--spacing-md);
+    border: 2px solid var(--border-color);
+    border-radius: var(--border-radius);
+    font-size: var(--font-size-base);
+}
+
+.additional-info textarea.speculated {
+    border-color: var(--danger-color);
+    background-color: #ffe6e6;
+}
+
 .confirmation-actions {
     display: flex;
     gap: var(--spacing-md);


### PR DESCRIPTION
## Summary
- allow fillExtractedInfo to put extra fields in a secondary textbox
- render an `additional-info` area for overflow items
- style the new textbox and show it in red if values are speculative

## Testing
- `python -m py_compile start_simple.py real_protocol_generator.py`