### PR TITLE
Improve streaming and update default LLM settings

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,8 +5,8 @@ const API_BASE_URL = 'http://localhost:8000';
 let currentConfig = {
     llm: {
         type: 'local',
-        url: 'http://192.168.22.191:8000/v1',
-        model: '/home/aiteam/.cache/modelscope/hub/models/google/medgemma-27b-text-it/',
+        url: 'https://v1.voct.top/v1',
+        model: 'gpt-4.1-mini',
         key: 'EMPTY',
         temperature: 0.3
     },
@@ -682,8 +682,8 @@ window.resetConfiguration = function() {
     currentConfig = {
         llm: {
             type: 'local',
-            url: 'http://192.168.22.191:8000/v1',
-            model: '/home/aiteam/.cache/modelscope/hub/models/google/medgemma-27b-text-it/',
+            url: 'https://v1.voct.top/v1',
+            model: 'gpt-4.1-mini',
             key: 'EMPTY',
             temperature: 0.3
         },
@@ -1479,6 +1479,17 @@ function formatFieldName(fieldName) {
         primary_endpoint: '主要终点',
         study_phase: '研究阶段',
         estimated_enrollment: '预计入组'
+    };
+    return nameMap[fieldName] || fieldName;
+}
+
+// 渲染协议大纲编辑器
+function fillOutlineEditor(outline) {
+    const editor = document.getElementById('outline-editor');
+    if (!editor) return;
+
+    editor.innerHTML = `
+        <div class="outline-list">
             ${outline.map((section, index) => createOutlineItemHTML(section, index)).join('')}
         </div>
         <div class="outline-actions-bottom">

--- a/start_simple.py
+++ b/start_simple.py
@@ -137,8 +137,8 @@ class ChatRequest(BaseModel):
 current_config = {
     "llm": {
         "type": "local",
-        "url": "http://192.168.22.191:8000/v1",
-        "model": "/home/aiteam/.cache/modelscope/hub/models/google/medgemma-27b-text-it/",
+        "url": "https://v1.voct.top/v1",
+        "model": "gpt-4.1-mini",
         "key": "EMPTY",
         "temperature": 0.3
     },
@@ -299,6 +299,54 @@ def call_local_llm(message: str, temperature: float = 0.3) -> str:
         logger.error(f"LLM调用失败: {e}")
         return f"抱歉，LLM调用失败: {str(e)}"
 
+def call_local_llm_stream(message: str, temperature: float = 0.3):
+    """调用本地LLM模型并以流方式返回内容"""
+    try:
+        headers = {
+            "Authorization": f"Bearer {current_config['llm']['key']}",
+            "Content-Type": "application/json"
+        }
+
+        data = {
+            "model": current_config["llm"]["model"],
+            "messages": [
+                {"role": "system", "content": "你是一个专业的医学AI助手，专门帮助用户处理临床试验方案相关的问题。请用中文回复。"},
+                {"role": "user", "content": message}
+            ],
+            "temperature": temperature,
+            "stream": True,
+            "max_tokens": 1000
+        }
+
+        with requests.post(
+            f"{current_config['llm']['url']}/chat/completions",
+            headers=headers,
+            json=data,
+            stream=True,
+            timeout=60
+        ) as resp:
+            if resp.status_code != 200:
+                yield f"[ERROR] {resp.status_code}"
+                return
+
+            for line in resp.iter_lines(decode_unicode=True):
+                if not line:
+                    continue
+                if line.startswith("data: "):
+                    try:
+                        payload = json.loads(line[6:])
+                        if payload.get("choices"):
+                            delta = payload["choices"][0]["delta"].get("content", "")
+                            if delta:
+                                yield delta
+                            if payload["choices"][0].get("finish_reason") is not None:
+                                break
+                    except Exception as parse_error:
+                        logger.warning(f"流式解析失败: {parse_error}")
+                        break
+    except Exception as e:
+        logger.error(f"LLM流式调用失败: {e}")
+
 @app.get("/")
 async def root():
     """根路径，返回API信息"""
@@ -379,12 +427,8 @@ async def chat_with_llm_stream(request: ChatRequest):
 
     async def generate_chat():
         try:
-            response_text = call_local_llm(request.message, request.temperature)
-
-            for chunk in chunk_text(response_text, chunk_size=50, overlap=0):
-                yield f"data: {json.dumps({'content': chunk})}\n\n"
-                await asyncio.sleep(0.02)
-
+            for token in call_local_llm_stream(request.message, request.temperature):
+                yield f"data: {json.dumps({'content': token})}\n\n"
             yield "data: {\"done\": true}\n\n"
         except Exception as e:
             yield f"data: {json.dumps({'error': str(e), 'done': True})}\n\n"
@@ -473,8 +517,8 @@ async def test_embedding_model():
 @app.post("/config/update")
 async def update_configuration(
     llm_type: str = Form("local"),
-    llm_url: str = Form("http://192.168.22.191:8000/v1"),
-    llm_model: str = Form("/home/aiteam/.cache/modelscope/hub/models/google/medgemma-27b-text-it/"),
+    llm_url: str = Form("https://v1.voct.top/v1"),
+    llm_model: str = Form("gpt-4.1-mini"),
     llm_key: str = Form(""),
     llm_temperature: float = Form(0.3),
     embed_type: str = Form("sentence-transformers"),
@@ -1827,19 +1871,26 @@ async def generate_protocol_stream(request: ProtocolStreamRequest):
                 )
                 
                 # 调用LLM生成该模块内容
-                module_content = call_local_llm(module_prompt, temperature=0.3)
-                
-                # 流式输出
-                chunk_data = {
-                    "content": f"\n## {section['title']}\n\n{module_content}\n",
+                yield f"data: {json.dumps({'content': '\n## ' + section['title'] + '\n\n', 'done': False})}\n\n"
+                section_content = ""
+                for token in call_local_llm_stream(module_prompt, temperature=0.3):
+                    chunk_data = {
+                        "content": token,
+                        "progress": idx / total_sections,
+                        "current_module": section['title'],
+                        "done": False
+                    }
+                    yield f"data: {json.dumps(chunk_data)}\n\n"
+                    section_content += token
+                    await asyncio.sleep(0)
+
+                full_content += f"\n## {section['title']}\n\n{section_content}\n"
+                progress_data = {
                     "progress": (idx + 1) / total_sections,
                     "current_module": section['title'],
                     "done": False
                 }
-                yield f"data: {json.dumps(chunk_data)}\n\n"
-                
-                full_content += chunk_data["content"]
-                await asyncio.sleep(0.1)  # 给前端时间渲染
+                yield f"data: {json.dumps(progress_data)}\n\n"
             
             # 3. 质量检查（如果启用）
             if request.settings.get('include_quality_check', True):
@@ -1917,12 +1968,11 @@ async def generate_section_stream(request: SectionStreamRequest):
             else:
                 prompt = generate_protocol_with_knowledge_enhancement(request.section['title'], request.confirmed_info, knowledge_results[:3])
 
-            content = call_local_llm(prompt, temperature=request.settings.get('detail_level', 0.3))
-            data = {
-                "content": f"\n## {request.section['title']}\n\n{content}\n",
-                "done": True
-            }
-            yield f"data: {json.dumps(data)}\n\n"
+            yield f"data: {json.dumps({'content': '\n## ' + request.section['title'] + '\n\n', 'done': False})}\n\n"
+            for token in call_local_llm_stream(prompt, temperature=request.settings.get('detail_level', 0.3)):
+                yield f"data: {json.dumps({'content': token})}\n\n"
+                await asyncio.sleep(0)
+            yield "data: {\"done\": true}\n\n"
         except Exception as e:
             yield f"data: {json.dumps({'error': str(e), 'done': True})}\n\n"
 


### PR DESCRIPTION
## Summary
- enable true token streaming from backend
- update default LLM URL and model to `https://v1.voct.top/v1` and `gpt-4.1-mini`
- keep UI defaults consistent with backend

## Testing
- `node -c script.js`
- `python -m py_compile start_simple.py real_protocol_generator.py`
