### PR TITLE
Add streaming prompts to protocol generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -631,6 +631,8 @@
                                     </div>
                                     
                                     <!-- 动态生成的内容将在这里显示 -->
+                                    <div class="prompt-viewer" id="prompt-viewer" style="display:none;"></div>
+                                    <div id="streaming-content"></div>
                                 </div>
                                 
                                 <div class="content-footer" id="content-footer" style="display: none;">

--- a/start_simple.py
+++ b/start_simple.py
@@ -137,8 +137,8 @@ class ChatRequest(BaseModel):
 current_config = {
     "llm": {
         "type": "local",
-        "url": "http://192.168.22.191:8000/v1",
-        "model": "/home/aiteam/.cache/modelscope/hub/models/google/medgemma-27b-text-it/",
+        "url": "https://v1.voct.top/v1",
+        "model": "gpt-4.1-mini",
         "key": "EMPTY",
         "temperature": 0.3
     },
@@ -298,6 +298,55 @@ def call_local_llm(message: str, temperature: float = 0.3) -> str:
     except Exception as e:
         logger.error(f"LLM调用失败: {e}")
         return f"抱歉，LLM调用失败: {str(e)}"
+
+def call_local_llm_stream(message: str, system_prompt: str = None, temperature: float = 0.3):
+    """流式调用本地LLM模型，直接转发生成的token"""
+    headers = {
+        "Authorization": f"Bearer {current_config['llm']['key']}",
+        "Content-Type": "application/json"
+    }
+
+    messages = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    messages.append({"role": "user", "content": message})
+
+    data = {
+        "model": current_config["llm"]["model"],
+        "messages": messages,
+        "temperature": temperature,
+        "max_tokens": 2000,
+        "stream": True
+    }
+
+    try:
+        with requests.post(
+            f"{current_config['llm']['url']}/chat/completions",
+            headers=headers,
+            json=data,
+            stream=True,
+            timeout=60
+        ) as r:
+            if r.status_code != 200:
+                raise ValueError(f"API调用失败: {r.status_code} - {r.text}")
+
+            for line in r.iter_lines():
+                if not line:
+                    continue
+                if line.startswith(b'data:'):
+                    payload = line[5:].strip()
+                    if payload == b"[DONE]":
+                        break
+                    try:
+                        event = json.loads(payload.decode())
+                        delta = event.get("choices", [{}])[0].get("delta", {}).get("content")
+                        if delta:
+                            yield delta
+                    except json.JSONDecodeError:
+                        continue
+    except Exception as e:
+        logger.error(f"LLM流式调用失败: {e}")
+        raise
 
 @app.get("/")
 async def root():
@@ -473,8 +522,8 @@ async def test_embedding_model():
 @app.post("/config/update")
 async def update_configuration(
     llm_type: str = Form("local"),
-    llm_url: str = Form("http://192.168.22.191:8000/v1"),
-    llm_model: str = Form("/home/aiteam/.cache/modelscope/hub/models/google/medgemma-27b-text-it/"),
+    llm_url: str = Form("https://v1.voct.top/v1"),
+    llm_model: str = Form("gpt-4.1-mini"),
     llm_key: str = Form(""),
     llm_temperature: float = Form(0.3),
     embed_type: str = Form("sentence-transformers"),
@@ -1408,6 +1457,76 @@ async def extract_key_info(request: KeyInfoExtractionRequest):
         logger.error(f"提取关键信息失败: {e}")
         raise HTTPException(status_code=500, detail=f"关键信息提取失败: {str(e)}")
 
+
+@app.post("/extract_key_info_stream")
+async def extract_key_info_stream(request: KeyInfoExtractionRequest):
+    """步骤1：流式提取关键信息并返回系统提示词"""
+    from fastapi.responses import StreamingResponse
+    import asyncio
+
+    async def generate():
+        try:
+            system_prompt = "你是一位专业的临床试验方案专家。请从用户输入中提取临床试验方案的关键信息。"
+            extraction_prompt = f"""
+请从以下文本中提取临床试验方案的关键信息，并以JSON格式返回。
+
+输入文本：
+{request.input_text}
+
+请提取以下关键信息：
+1. drug_type（药物类型）
+2. disease（目标疾病）
+3. trial_phase（试验分期）
+4. primary_objective（主要目的）
+5. primary_endpoint（主要终点）
+6. secondary_endpoints（次要终点）
+7. patient_population（目标人群）
+8. estimated_enrollment（预计入组）
+9. study_design（研究设计）
+10. treatment_line（治疗线数）
+
+返回纯JSON格式，不要有其他文字。
+"""
+
+            yield f"data: {json.dumps({'type': 'system_prompt', 'content': extraction_prompt})}\n\n"
+            await asyncio.sleep(0.1)
+
+            accumulated = ""
+            for token in call_local_llm_stream(extraction_prompt, system_prompt, 0.1):
+                accumulated += token
+                yield f"data: {json.dumps({'type': 'content', 'content': token})}\n\n"
+                await asyncio.sleep(0.02)
+
+            try:
+                import re
+                match = re.search(r'\{.*?\}', accumulated, re.DOTALL)
+                if match:
+                    info = json.loads(match.group())
+                else:
+                    info = {
+                        "drug_type": "待确定",
+                        "disease": "待确定",
+                        "trial_phase": "I期",
+                        "primary_objective": "评估安全性和耐受性",
+                        "primary_endpoint": "DLT/MTD",
+                        "secondary_endpoints": ["ORR", "PFS"],
+                        "patient_population": "待确定",
+                        "estimated_enrollment": "20-30例",
+                        "study_design": "开放标签、剂量递增研究",
+                        "treatment_line": "待确定"
+                    }
+                yield f"data: {json.dumps({'type': 'extracted_info', 'content': info})}\n\n"
+            except Exception as e:
+                logger.error(f"JSON解析失败: {e}")
+                yield f"data: {json.dumps({'type': 'error', 'content': '信息解析失败'})}\n\n"
+
+            yield f"data: {json.dumps({'type': 'done', 'content': ''})}\n\n"
+        except Exception as e:
+            logger.error(f"流式提取失败: {e}")
+            yield f"data: {json.dumps({'type': 'error', 'content': str(e)})}\n\n"
+
+    return StreamingResponse(generate(), media_type="text/event-stream", headers={"Cache-Control": "no-cache", "Connection": "keep-alive", "Access-Control-Allow-Origin": "*"})
+
 def validate_extraction_quality(info):
     """验证提取信息的质量"""
     quality_score = 100
@@ -1545,6 +1664,58 @@ async def generate_outline(request: OutlineGenerationRequest):
     except Exception as e:
         logger.error(f"生成大纲失败: {e}")
         raise HTTPException(status_code=500, detail=f"大纲生成失败: {str(e)}")
+
+
+@app.post("/generate_outline_stream")
+async def generate_outline_stream(request: OutlineGenerationRequest):
+    """步骤2：流式生成协议大纲"""
+    from fastapi.responses import StreamingResponse
+    import asyncio
+
+    async def generate():
+        try:
+            system_prompt = "你是一位临床试验方案撰写专家。请生成符合ICH-GCP标准的临床试验方案章节目录。"
+            outline_prompt = f"""
+基于以下确认的临床试验信息，生成一个完整的临床试验方案大纲：
+
+确认信息：
+{json.dumps(request.confirmed_info, ensure_ascii=False, indent=2)}
+
+请生成标准的临床试验方案章节目录，要求：
+1. 共10个主要章节
+2. 每个章节下有3-5个子章节
+3. 只返回章节标题，不要描述内容
+4. 返回JSON数组格式
+"""
+
+            yield f"data: {json.dumps({'type': 'system_prompt', 'content': outline_prompt})}\n\n"
+            await asyncio.sleep(0.1)
+
+            accumulated = ""
+            for token in call_local_llm_stream(outline_prompt, system_prompt, 0.2):
+                accumulated += token
+                yield f"data: {json.dumps({'type': 'content', 'content': token})}\n\n"
+                await asyncio.sleep(0.02)
+
+            try:
+                import re
+                match = re.search(r'\[.*?\]', accumulated, re.DOTALL)
+                if match:
+                    outline = json.loads(match.group())
+                else:
+                    outline = get_standard_outline_template(request.confirmed_info)
+                yield f"data: {json.dumps({'type': 'outline', 'content': outline})}\n\n"
+            except Exception as e:
+                logger.error(f"大纲解析失败: {e}")
+                outline = get_standard_outline_template(request.confirmed_info)
+                yield f"data: {json.dumps({'type': 'outline', 'content': outline})}\n\n"
+
+            yield f"data: {json.dumps({'type': 'done', 'content': ''})}\n\n"
+        except Exception as e:
+            logger.error(f"大纲生成失败: {e}")
+            yield f"data: {json.dumps({'type': 'error', 'content': str(e)})}\n\n"
+
+    return StreamingResponse(generate(), media_type="text/event-stream", headers={"Cache-Control": "no-cache", "Connection": "keep-alive", "Access-Control-Allow-Origin": "*"})
 
 def get_standard_protocol_outline(confirmed_info):
     """获取标准的临床试验方案大纲模板"""
@@ -1917,14 +2088,16 @@ async def generate_section_stream(request: SectionStreamRequest):
             else:
                 prompt = generate_protocol_with_knowledge_enhancement(request.section['title'], request.confirmed_info, knowledge_results[:3])
 
-            content = call_local_llm(prompt, temperature=request.settings.get('detail_level', 0.3))
-            data = {
-                "content": f"\n## {request.section['title']}\n\n{content}\n",
-                "done": True
-            }
-            yield f"data: {json.dumps(data)}\n\n"
+            yield f"data: {json.dumps({'type': 'system_prompt', 'content': prompt})}\n\n"
+            await asyncio.sleep(0.1)
+            section_header = f"\n## {request.section.get('title', '')}\n\n"
+            yield f"data: {json.dumps({'type': 'section_start', 'content': section_header})}\n\n"
+            for token in call_local_llm_stream(prompt, None, request.settings.get('detail_level', 0.3)):
+                yield f"data: {json.dumps({'type': 'content', 'content': token})}\n\n"
+                await asyncio.sleep(0.02)
+            yield f"data: {json.dumps({'type': 'done', 'content': ''})}\n\n"
         except Exception as e:
-            yield f"data: {json.dumps({'error': str(e), 'done': True})}\n\n"
+            yield f"data: {json.dumps({'type': 'error', 'content': str(e)})}\n\n"
 
     return StreamingResponse(
         stream(),

--- a/style.css
+++ b/style.css
@@ -1842,6 +1842,17 @@ body {
     line-height: 1.6;
 }
 
+.prompt-viewer {
+    background: #f8f9fa;
+    border: 1px solid #e0e0e0;
+    padding: var(--spacing-sm);
+    margin-bottom: var(--spacing-sm);
+    max-height: 200px;
+    overflow-y: auto;
+    white-space: pre-wrap;
+    font-size: 0.9rem;
+}
+
 .content-viewer h1,
 .content-viewer h2,
 .content-viewer h3 {


### PR DESCRIPTION
## Summary
- set default model to `gpt-4.1-mini` and update config endpoint
- implement `call_local_llm_stream` and streaming API endpoints
- show system prompts and streaming content in UI
- add prompt viewer styles

## Testing
- `node -c script.js`
- `python -m py_compile start_simple.py real_protocol_generator.py`
