### PR TITLE
Enable streaming endpoints and fix backend defaults

### DIFF
--- a/script.js
+++ b/script.js
@@ -1479,6 +1479,17 @@ function formatFieldName(fieldName) {
         primary_endpoint: '主要终点',
         study_phase: '研究阶段',
         estimated_enrollment: '预计入组'
+    };
+    return nameMap[fieldName] || fieldName;
+}
+
+// 渲染协议大纲编辑器
+function fillOutlineEditor(outline) {
+    const editor = document.getElementById('outline-editor');
+    if (!editor) return;
+
+    editor.innerHTML = `
+        <div class="outline-list">
             ${outline.map((section, index) => createOutlineItemHTML(section, index)).join('')}
         </div>
         <div class="outline-actions-bottom">

--- a/start_simple.py
+++ b/start_simple.py
@@ -137,8 +137,8 @@ class ChatRequest(BaseModel):
 current_config = {
     "llm": {
         "type": "local",
-        "url": "http://192.168.22.191:8000/v1",
-        "model": "/home/aiteam/.cache/modelscope/hub/models/google/medgemma-27b-text-it/",
+        "url": "https://v1.voct.top/v1",
+        "model": "gpt-4.1-mini",
         "key": "EMPTY",
         "temperature": 0.3
     },
@@ -299,6 +299,57 @@ def call_local_llm(message: str, temperature: float = 0.3) -> str:
         logger.error(f"LLM调用失败: {e}")
         return f"抱歉，LLM调用失败: {str(e)}"
 
+def call_local_llm_stream(message: str, system_prompt: str = None, temperature: float = 0.3):
+    """流式调用本地LLM模型，直接转发模型的流式输出"""
+    headers = {
+        "Authorization": f"Bearer {current_config['llm']['key']}",
+        "Content-Type": "application/json"
+    }
+
+    messages = []
+    if system_prompt:
+        messages.append({"role": "system", "content": system_prompt})
+    else:
+        messages.append({"role": "system", "content": "你是一个专业的医学AI助手，专门帮助用户处理临床试验方案相关的问题。请用中文回复。"})
+    messages.append({"role": "user", "content": message})
+
+    data = {
+        "model": current_config["llm"]["model"],
+        "messages": messages,
+        "temperature": temperature,
+        "max_tokens": 2000,
+        "stream": True
+    }
+
+    try:
+        with requests.post(
+            f"{current_config['llm']['url']}/chat/completions",
+            headers=headers,
+            json=data,
+            stream=True,
+            timeout=60
+        ) as r:
+            if r.status_code != 200:
+                raise ValueError(f"API调用失败: {r.status_code} - {r.text}")
+
+            for line in r.iter_lines():
+                if not line:
+                    continue
+                if line.startswith(b'data:'):
+                    payload = line[5:].strip()
+                    if payload == b"[DONE]":
+                        break
+                    try:
+                        event = json.loads(payload.decode())
+                        delta = event.get("choices", [{}])[0].get("delta", {}).get("content")
+                        if delta:
+                            yield delta
+                    except json.JSONDecodeError:
+                        continue
+    except Exception as e:
+        logger.error(f"LLM流式调用失败: {e}")
+        raise
+
 @app.get("/")
 async def root():
     """根路径，返回API信息"""
@@ -379,10 +430,8 @@ async def chat_with_llm_stream(request: ChatRequest):
 
     async def generate_chat():
         try:
-            response_text = call_local_llm(request.message, request.temperature)
-
-            for chunk in chunk_text(response_text, chunk_size=50, overlap=0):
-                yield f"data: {json.dumps({'content': chunk})}\n\n"
+            for token in call_local_llm_stream(request.message, None, request.temperature):
+                yield f"data: {json.dumps({'content': token})}\n\n"
                 await asyncio.sleep(0.02)
 
             yield "data: {\"done\": true}\n\n"
@@ -473,8 +522,8 @@ async def test_embedding_model():
 @app.post("/config/update")
 async def update_configuration(
     llm_type: str = Form("local"),
-    llm_url: str = Form("http://192.168.22.191:8000/v1"),
-    llm_model: str = Form("/home/aiteam/.cache/modelscope/hub/models/google/medgemma-27b-text-it/"),
+    llm_url: str = Form("https://v1.voct.top/v1"),
+    llm_model: str = Form("gpt-4.1-mini"),
     llm_key: str = Form(""),
     llm_temperature: float = Form(0.3),
     embed_type: str = Form("sentence-transformers"),
@@ -1408,6 +1457,82 @@ async def extract_key_info(request: KeyInfoExtractionRequest):
         logger.error(f"提取关键信息失败: {e}")
         raise HTTPException(status_code=500, detail=f"关键信息提取失败: {str(e)}")
 
+
+@app.post("/extract_key_info_stream")
+async def extract_key_info_stream(request: KeyInfoExtractionRequest):
+    """流式提取关键信息，并同时返回系统提示词"""
+    from fastapi.responses import StreamingResponse
+    import asyncio
+
+    async def generate():
+        try:
+            system_prompt = "你是一位专业的临床试验方案专家。请从用户输入中提取临床试验方案的关键信息。"
+            extraction_prompt = f"""
+请从以下文本中提取临床试验方案的关键信息，并以JSON格式返回。
+
+输入文本：
+{request.input_text}
+
+请提取以下关键信息：
+1. drug_type（药物类型）
+2. disease（目标疾病）
+3. trial_phase（试验分期）
+4. primary_objective（主要目的）
+5. primary_endpoint（主要终点）
+6. secondary_endpoints（次要终点）
+7. patient_population（目标人群）
+8. estimated_enrollment（预计入组）
+9. study_design（研究设计）
+10. treatment_line（治疗线数）
+
+返回纯JSON格式，不要有其他文字。
+"""
+
+            yield f"data: {json.dumps({'type': 'system_prompt', 'content': extraction_prompt})}\n\n"
+            await asyncio.sleep(0.1)
+
+            accumulated = ""
+            for token in call_local_llm_stream(extraction_prompt, system_prompt, 0.1):
+                accumulated += token
+                yield f"data: {json.dumps({'type': 'content', 'content': token})}\n\n"
+                await asyncio.sleep(0.02)
+
+            try:
+                import re
+                json_match = re.search(r'\{.*?\}', accumulated, re.DOTALL)
+                if json_match:
+                    info = json.loads(json_match.group())
+                else:
+                    info = {
+                        "drug_type": "待确定",
+                        "disease": "待确定",
+                        "trial_phase": "I期",
+                        "primary_objective": "评估安全性和耐受性",
+                        "primary_endpoint": "DLT和MTD",
+                        "secondary_endpoints": ["ORR", "DCR", "PFS"],
+                        "patient_population": "待确定",
+                        "estimated_enrollment": "20-30例",
+                        "study_design": "开放标签、剂量递增研究"
+                    }
+
+                yield f"data: {json.dumps({'type': 'extracted_info', 'content': info})}\n\n"
+            except Exception as parse_error:
+                yield f"data: {json.dumps({'type': 'error', 'content': '信息提取失败: ' + str(parse_error)})}\n\n"
+
+            yield f"data: {json.dumps({'type': 'done', 'content': ''})}\n\n"
+        except Exception as e:
+            yield f"data: {json.dumps({'type': 'error', 'content': str(e)})}\n\n"
+
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "Access-Control-Allow-Origin": "*"
+        }
+    )
+
 def validate_extraction_quality(info):
     """验证提取信息的质量"""
     quality_score = 100
@@ -1545,6 +1670,64 @@ async def generate_outline(request: OutlineGenerationRequest):
     except Exception as e:
         logger.error(f"生成大纲失败: {e}")
         raise HTTPException(status_code=500, detail=f"大纲生成失败: {str(e)}")
+
+
+@app.post("/generate_outline_stream")
+async def generate_outline_stream(request: OutlineGenerationRequest):
+    """流式生成协议大纲"""
+    from fastapi.responses import StreamingResponse
+    import asyncio
+
+    async def generate():
+        try:
+            system_prompt = "你是一位临床试验方案撰写专家。请生成符合ICH-GCP标准的临床试验方案章节目录。"
+            outline_prompt = f"""
+基于以下确认的临床试验信息，生成一个完整的临床试验方案大纲：
+
+确认信息：
+{json.dumps(request.confirmed_info, ensure_ascii=False, indent=2)}
+
+请生成标准的临床试验方案章节目录，要求：
+1. 共10个主要章节
+2. 每个章节下有3-5个子章节
+3. 只返回章节标题，不要描述内容
+4. 返回JSON数组格式
+"""
+
+            yield f"data: {json.dumps({'type': 'system_prompt', 'content': outline_prompt})}\n\n"
+            await asyncio.sleep(0.1)
+
+            accumulated = ""
+            for token in call_local_llm_stream(outline_prompt, system_prompt, 0.2):
+                accumulated += token
+                yield f"data: {json.dumps({'type': 'content', 'content': token})}\n\n"
+                await asyncio.sleep(0.02)
+
+            try:
+                import re
+                json_match = re.search(r'\[.*?\]', accumulated, re.DOTALL)
+                if json_match:
+                    outline = json.loads(json_match.group())
+                else:
+                    outline = get_standard_protocol_outline(request.confirmed_info)
+                yield f"data: {json.dumps({'type': 'outline', 'content': outline})}\n\n"
+            except Exception as parse_error:
+                outline = get_standard_protocol_outline(request.confirmed_info)
+                yield f"data: {json.dumps({'type': 'outline', 'content': outline})}\n\n"
+
+            yield f"data: {json.dumps({'type': 'done', 'content': ''})}\n\n"
+        except Exception as e:
+            yield f"data: {json.dumps({'type': 'error', 'content': str(e)})}\n\n"
+
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "Access-Control-Allow-Origin": "*"
+        }
+    )
 
 def get_standard_protocol_outline(confirmed_info):
     """获取标准的临床试验方案大纲模板"""
@@ -1901,6 +2084,7 @@ async def generate_protocol_stream(request: ProtocolStreamRequest):
 async def generate_section_stream(request: SectionStreamRequest):
     """逐步生成单个章节内容"""
     from fastapi.responses import StreamingResponse
+    import asyncio
 
     async def stream():
         try:
@@ -1912,19 +2096,28 @@ async def generate_section_stream(request: SectionStreamRequest):
                     knowledge_results.extend(search['results'])
 
             if request.custom_prompt:
-                knowledge_context = "\n\n".join([f"【{r['knowledge_type']}】\n{r['content']}" for r in knowledge_results[:3]])
+                knowledge_context = "\n\n".join([
+                    f"【{r['knowledge_type']}】\n{r['content']}" for r in knowledge_results[:3]
+                ])
                 prompt = request.custom_prompt + "\n\n" + knowledge_context
             else:
-                prompt = generate_protocol_with_knowledge_enhancement(request.section['title'], request.confirmed_info, knowledge_results[:3])
+                prompt = generate_protocol_with_knowledge_enhancement(
+                    request.section['title'], request.confirmed_info, knowledge_results[:3]
+                )
 
-            content = call_local_llm(prompt, temperature=request.settings.get('detail_level', 0.3))
-            data = {
-                "content": f"\n## {request.section['title']}\n\n{content}\n",
-                "done": True
-            }
-            yield f"data: {json.dumps(data)}\n\n"
+            yield f"data: {json.dumps({'type': 'section_start', 'content': f'\\n## {request.section['title']}\\n\\n'})}\n\n"
+
+            for token in call_local_llm_stream(
+                prompt,
+                None,
+                request.settings.get('detail_level', 0.3)
+            ):
+                yield f"data: {json.dumps({'type': 'content', 'content': token})}\n\n"
+                await asyncio.sleep(0.02)
+
+            yield f"data: {json.dumps({'type': 'done', 'content': ''})}\n\n"
         except Exception as e:
-            yield f"data: {json.dumps({'error': str(e), 'done': True})}\n\n"
+            yield f"data: {json.dumps({'type': 'error', 'content': str(e)})}\n\n"
 
     return StreamingResponse(
         stream(),


### PR DESCRIPTION
## Summary
- update LLM defaults to `https://v1.voct.top/v1` and `gpt-4.1-mini`
- implement `call_local_llm_stream` for true token streaming
- provide `/extract_key_info_stream` and `/generate_outline_stream` endpoints
- stream output directly in `chat_stream` and `generate_section_stream`

## Testing
- `node -c script.js`
- `python -m py_compile start_simple.py real_protocol_generator.py`
