### PR TITLE
Fix streaming API defaults

### DIFF
--- a/script.js
+++ b/script.js
@@ -1469,16 +1469,13 @@ function fillExtractedInfo(info) {
     }
 }
 
-// 格式化字段名称
-function formatFieldName(fieldName) {
-    const nameMap = {
-        study_type: '研究类型',
-        drug_type: '药物类型',
-        indication: '适应症',
-        patient_population: '患者人群',
-        primary_endpoint: '主要终点',
-        study_phase: '研究阶段',
-        estimated_enrollment: '预计入组'
+// 渲染协议大纲编辑器
+function fillOutlineEditor(outline) {
+    const editor = document.getElementById('outline-editor');
+    if (!editor) return;
+
+    editor.innerHTML = `
+        <div class="outline-list">
             ${outline.map((section, index) => createOutlineItemHTML(section, index)).join('')}
         </div>
         <div class="outline-actions-bottom">


### PR DESCRIPTION
## Summary
- update global model defaults to `https://v1.voct.top/v1` with `gpt-4.1-mini`
- add `call_local_llm_stream` for forwarding LLM tokens
- use streaming helper in `/chat_stream`, `/generate_protocol_stream`, and `/generate_section_stream`
- remove duplicate helper in `script.js`

## Testing
- `node -c script.js`
- `python -m py_compile start_simple.py real_protocol_generator.py`
