### PR TITLE
Fix stuck loading overlay during LLM connection test

### DIFF
--- a/script.js
+++ b/script.js
@@ -667,6 +667,7 @@ window.testLLMConnection = async function() {
         showToast('LLM连接测试失败: ' + error.message, 'error');
     } finally {
         showSystemPrompt('');
+        hideLoading();
     }
 };
 


### PR DESCRIPTION
## Summary
- ensure loading overlay hides after LLM connection test

## Testing
- `python -m py_compile real_protocol_generator.py start_all.py start_frontend.py start_simple.py`