### PR TITLE
Fix duplicate prompt-viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -608,7 +608,6 @@
                                 </div>
                                 
                                 <div class="content-container" id="live-content-container">
-                                    <div id="prompt-viewer" class="prompt-viewer" style="display:none;"></div>
                                     <div class="welcome-message">
                                         <div class="welcome-icon">
                                             <i class="fas fa-lightbulb"></i>
@@ -632,7 +631,6 @@
                                     </div>
                                     
                                     <!-- 动态生成的内容将在这里显示 -->
-                                    <div class="prompt-viewer" id="prompt-viewer" style="display:none;"></div>
                                     <div id="streaming-content"></div>
                                 </div>
                                 

--- a/script.js
+++ b/script.js
@@ -1731,7 +1731,7 @@ async function generateCurrentSection() {
                         if (streamingContent) streamingContent.innerHTML += escapeHtml(data.content);
                     } else if (data.type === 'content') {
                         smartGenerationState.content += data.content;
-                        if (marked) {
+                        if (typeof marked !== 'undefined') {
                             streamingContent.innerHTML += marked.parse(data.content);
                         } else if (streamingContent) {
                             streamingContent.innerHTML += data.content.replace(/\n/g, '<br>');
@@ -1828,14 +1828,6 @@ function updateContentDisplay(content) {
 
     // 滚动到底部
     contentContainer.scrollTop = contentContainer.scrollHeight;
-}
-
-function showSystemPrompt(text) {
-    const promptEl = document.getElementById('prompt-viewer');
-    if (promptEl) {
-        promptEl.textContent = text;
-        promptEl.style.display = text ? 'block' : 'none';
-    }
 }
 
 function resetLiveContent() {


### PR DESCRIPTION
## Summary
- drop leftover prompt-viewer placeholder
- remove duplicate `showSystemPrompt` definition

## Testing
- `python -m py_compile start_simple.py real_protocol_generator.py`
- `python -m py_compile start_frontend.py start_all.py`
