### PR TITLE
Improve generation stats and template support

### DIFF
--- a/index.html
+++ b/index.html
@@ -585,6 +585,10 @@
                                             <span class="slider-value" id="detail-level-value">70%</span>
                                         </div>
                                     </div>
+                                    <div class="setting-item">
+                                        <label for="generation-template">章节模板</label>
+                                        <textarea id="generation-template" rows="4" placeholder="可选：生成时使用的模板"></textarea>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/start_simple.py
+++ b/start_simple.py
@@ -2404,7 +2404,8 @@ async def generate_protocol_stream(request: ProtocolStreamRequest):
                             knowledge_results.extend(search_result['results'])
             
             # 2. 按照大纲逐个模块生成内容
-            full_content = ""
+            template_prefix = request.settings.get('template', '') or ''
+            full_content = template_prefix
             total_sections = len(request.outline)
             
             for idx, section in enumerate(request.outline):


### PR DESCRIPTION
## Summary
- show completed modules and char count during streaming generation
- allow specifying a section template in the UI
- forward template to backend and prepend it to generated content

## Testing
- `node --check script.js`
- `python -m py_compile start_simple.py`
