### PR TITLE
Center editor modals and load default prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -421,6 +421,10 @@
                                                 <i class="fas fa-wand-magic-sparkles"></i>
                                                 智能提取关键信息
                                             </button>
+                                            <button class="btn btn-secondary btn-lg" onclick="manualInputInfo()" style="margin-left:0.5rem;">
+                                                <i class="fas fa-keyboard"></i>
+                                                手动输入
+                                            </button>
                                         </div>
                                     </div>
                                 </div>
@@ -458,6 +462,10 @@
                                             <button class="btn btn-primary" onclick="proceedToOutline()">
                                                 <i class="fas fa-arrow-right"></i>
                                                 确认信息，生成目录
+                                            </button>
+                                            <button class="btn btn-secondary" onclick="skipToDefaultOutline()" style="margin-left:0.5rem;">
+                                                <i class="fas fa-forward"></i>
+                                                跳过
                                             </button>
                                         </div>
                                     </div>

--- a/script.js
+++ b/script.js
@@ -1369,6 +1369,37 @@ let smartGenerationState = {
     sectionPrompts: []
 };
 
+// 手动填入默认信息
+window.manualInputInfo = function() {
+    const defaultInfo = {
+        drug_type: '示例药物',
+        indication: '示例疾病',
+        study_phase: 'I期',
+        additional: '请在此补充其他信息'
+    };
+    smartGenerationState.extractedInfo = defaultInfo;
+    fillExtractedInfo(defaultInfo);
+    switchGenerationStep(2);
+    showToast('已填入默认信息，请确认或调整', 'success');
+};
+
+// 跳过确认信息，直接生成默认目录
+window.skipToDefaultOutline = function() {
+    const mockOutline = [
+        { title: '1. 研究背景与目的', content: '描述研究背景、科学依据和研究目的' },
+        { title: '2. 研究设计', content: '详细说明研究类型、设计方案和实施方法' },
+        { title: '3. 研究对象', content: '定义入组标准、排除标准和受试者筛选流程' },
+        { title: '4. 给药方案', content: '详细描述药物给药方案、剂量递增和安全监测' },
+        { title: '5. 安全性评估', content: '安全性监测指标、不良事件处理和停药标准' },
+        { title: '6. 疗效评估', content: '主要终点和次要终点的评估方法和时间点' },
+        { title: '7. 统计分析', content: '样本量计算、统计分析方法和数据管理' }
+    ];
+    smartGenerationState.generatedOutline = mockOutline;
+    fillOutlineEditor(mockOutline);
+    switchGenerationStep(3);
+    showToast('已跳过信息确认，使用默认目录', 'info');
+};
+
 // 确认信息并生成目录
 window.proceedToOutline = async function() {
     console.log('proceedToOutline 函数被调用');
@@ -1487,7 +1518,8 @@ function formatFieldName(fieldName) {
         patient_population: '患者人群',
         primary_endpoint: '主要终点',
         study_phase: '研究阶段',
-        estimated_enrollment: '预计入组'
+        estimated_enrollment: '预计入组',
+        additional: '附加信息'
     };
     return nameMap[fieldName] || fieldName;
 }
@@ -1690,6 +1722,9 @@ function renderSectionOutline() {
     if (outlineEl) {
         outlineEl.textContent = section ? formatOutlineContent(section) : '';
     }
+
+    const existingPrompt = smartGenerationState.sectionPrompts[index];
+    showSystemPrompt(existingPrompt || '');
 }
 
 // 从目录直接开始一键生成全文
@@ -2111,7 +2146,7 @@ window.openContentEditor = function() {
     if (modal && textarea) {
         textarea.value = smartGenerationState.content || '';
         textarea.addEventListener('input', handleEditorInput);
-        modal.style.display = 'flex';
+        modal.classList.add('active');
         document.body.classList.add('modal-open');
     }
 };
@@ -2129,6 +2164,7 @@ window.closeContentEditor = function() {
     const modal = document.getElementById('content-editor-modal');
     const textarea = document.getElementById('content-editor-text');
     if (modal) {
+        modal.classList.remove('active');
         modal.style.display = 'none';
         document.body.classList.remove('modal-open');
     }
@@ -2141,12 +2177,18 @@ window.closeContentEditor = function() {
 window.openPromptEditor = function() {
     const index = smartGenerationState.currentModuleIndex;
     editingPromptIndex = index;
-    const prompt = smartGenerationState.sectionPrompts[index] || '';
+    let prompt = smartGenerationState.sectionPrompts[index];
+    if (!prompt) {
+        const viewer = document.getElementById('prompt-viewer');
+        if (viewer) {
+            prompt = viewer.textContent.trim();
+        }
+    }
     const modal = document.getElementById('prompt-editor-modal');
     const textarea = document.getElementById('prompt-modal-text');
     if (modal && textarea) {
-        textarea.value = prompt;
-        modal.style.display = 'flex';
+        textarea.value = prompt || '';
+        modal.classList.add('active');
         document.body.classList.add('modal-open');
     }
 };
@@ -2154,6 +2196,7 @@ window.openPromptEditor = function() {
 window.cancelPromptEdit = function() {
     const modal = document.getElementById('prompt-editor-modal');
     if (modal) {
+        modal.classList.remove('active');
         modal.style.display = 'none';
         document.body.classList.remove('modal-open');
     }
@@ -2185,7 +2228,7 @@ window.handlePromptFile = function(event) {
         const textarea = document.getElementById('prompt-modal-text');
         if (modal && textarea) {
             textarea.value = text;
-            modal.style.display = 'flex';
+            modal.classList.add('active');
             document.body.classList.add('modal-open');
         }
     };


### PR DESCRIPTION
## Summary
- adjust modal logic so editor dialogs appear centered
- load the current system prompt when opening the prompt editor
- add manual input option for key info
- allow skipping info confirmation with a default outline
- show stored section prompts when switching chapters

## Testing
- `pytest -q`