### PR TITLE
Update generation UI with thinking indicator

### DIFF
--- a/index.html
+++ b/index.html
@@ -553,7 +553,7 @@
                                         
                                         <div class="generation-stats">
                                             <div class="stat-item">
-                                                <span class="stat-label">已完成模块</span>
+                                                <span class="stat-label">已完成</span>
                                                 <span class="stat-value" id="completed-modules">0</span>
                                             </div>
                                             <div class="stat-item">

--- a/script.js
+++ b/script.js
@@ -633,10 +633,32 @@ function showSystemPrompt(text) {
         if (text) {
             promptEl.style.display = 'block';
             promptEl.textContent = text;
+            showThinkingIndicator();
         } else {
             promptEl.style.display = 'none';
             promptEl.textContent = '';
+            hideThinkingIndicator();
         }
+    }
+}
+
+function showThinkingIndicator() {
+    let indicator = document.getElementById('thinking-indicator');
+    const container = document.getElementById('streaming-content');
+    if (!container) return;
+    if (!indicator) {
+        indicator = document.createElement('div');
+        indicator.id = 'thinking-indicator';
+        indicator.innerHTML = '思考中 <span class="spinner"></span>';
+        container.parentNode.insertBefore(indicator, container.nextSibling);
+    }
+    indicator.style.display = 'flex';
+}
+
+function hideThinkingIndicator() {
+    const indicator = document.getElementById('thinking-indicator');
+    if (indicator) {
+        indicator.style.display = 'none';
     }
 }
 
@@ -1776,8 +1798,6 @@ function renderModuleControls() {
     const kbOptions = document.getElementById('kb-options');
     const promptEl = document.getElementById('custom-prompt');
     const btn = document.getElementById('generate-section-btn');
-    const stepHeaderTitle = document.querySelector('#step-4 .step-header-content h3');
-
 
     if (!section) {
         titleEl.textContent = '全部章节生成完成';
@@ -1789,7 +1809,6 @@ function renderModuleControls() {
         return;
     }
 
-    if (stepHeaderTitle) stepHeaderTitle.textContent = '生成章节: ' + section.title;
     if (titleEl) titleEl.textContent = '知识库选择';
     kbOptions.innerHTML = availableKnowledgeTypes.map(t => `<label><input type="checkbox" value="${t}" checked> ${t}</label>`).join('');
     promptEl.value = '';
@@ -1885,6 +1904,7 @@ async function generateCurrentSection() {
                 }
 
                 if (data.content || data.section_start) {
+                    hideThinkingIndicator();
                     if (typeof marked !== 'undefined') {
                         streamingContent.innerHTML = marked.parse(accumulated);
                     } else if (streamingContent) {
@@ -2523,34 +2543,8 @@ function initializeStepNavigation() {
         </div>
     `;
     
-    // 为每个步骤添加头部
-    document.querySelectorAll('.generation-step').forEach((step, index) => {
-        const stepNumber = index + 1;
-        const stepTitles = [
-            '需求输入',
-            '信息确认',
-            '目录调整',
-            '生成章节'
-        ];
-        const stepDescriptions = [
-            '请详细描述您的临床试验研究需求',
-            'AI已自动提取关键信息，请确认或调整',
-            '根据您的需求，AI生成了以下方案目录结构，您可以调整',
-            '正在智能生成完整的临床试验方案'
-        ];
-        
-        const headerHTML = `
-            <div class="step-header-content">
-                <div class="step-number-badge">${stepNumber}</div>
-                <div class="step-title">
-                    <h3>${stepTitles[index]}</h3>
-                    <p>${stepDescriptions[index]}</p>
-                </div>
-            </div>
-        `;
-        
-        step.insertAdjacentHTML('afterbegin', headerHTML);
-    });
+    // 移除自动生成的步骤标题
+    document.querySelectorAll('.step-header-content').forEach(el => el.remove());
     
     // 添加导航到步骤容器
     const stepsContainerElement = document.querySelector('.generation-steps-container') || 

--- a/style.css
+++ b/style.css
@@ -386,6 +386,10 @@ body {
     transform: translateY(-1px);
 }
 
+#generate-all-btn {
+    justify-content: center;
+}
+
 .btn-outline {
     background: transparent;
     color: var(--primary-color);
@@ -1955,6 +1959,30 @@ body {
 
 .content-viewer li {
     margin-bottom: var(--spacing-xs);
+}
+
+/* 思考中指示器 */
+#thinking-indicator {
+    margin-top: var(--spacing-sm);
+    color: var(--secondary-color);
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    font-style: italic;
+}
+
+#thinking-indicator .spinner {
+    width: 1rem;
+    height: 1rem;
+    border: 2px solid var(--border-color);
+    border-top-color: var(--primary-color);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
 }
 
 /* 响应式改进 */


### PR DESCRIPTION
## Summary
- update progress label text
- center text on 'generate all' button
- remove auto-added step headers
- show thinking indicator before stream output
- hide indicator when output received

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683a4c1f507c8326857d84b26a7a439a