### PR TITLE
Refactor front-end scripts into modules

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,0 +1,71 @@
+import state from './state.js';
+import { showToast, showLoading, hideLoading, showSystemPrompt } from './ui.js';
+
+export async function updateBackendConfiguration() {
+    try {
+        const formData = new FormData();
+        formData.append('llm_type', state.currentConfig.llm.type);
+        formData.append('llm_url', state.currentConfig.llm.url);
+        formData.append('llm_model', state.currentConfig.llm.model);
+        formData.append('llm_key', state.currentConfig.llm.key);
+        formData.append('llm_temperature', state.currentConfig.llm.temperature);
+        formData.append('embed_type', state.currentConfig.embedding.type);
+        formData.append('embed_url', state.currentConfig.embedding.url);
+        formData.append('embed_key', state.currentConfig.embedding.key);
+        formData.append('embed_model', state.currentConfig.embedding.model);
+        formData.append('embed_dimension', state.currentConfig.embedding.dimension);
+
+        const response = await fetch(`${state.API_BASE_URL}/config/update`, {
+            method: 'POST',
+            body: formData
+        });
+
+        if (response.ok) {
+            const result = await response.json();
+            console.log('后端配置更新成功:', result);
+        }
+    } catch (error) {
+        console.error('后端配置更新错误:', error);
+    }
+}
+
+export async function testLLMConnection() {
+    showLoading('测试LLM连接中...');
+    try {
+        const response = await fetch(`${state.API_BASE_URL}/test/llm`, {
+            method: 'POST'
+        });
+        const result = await response.json();
+
+        if (result.success) {
+            showToast('LLM连接测试成功: ' + result.response, 'success');
+        } else {
+            showToast('LLM连接测试失败: ' + result.message, 'error');
+        }
+    } catch (error) {
+        showToast('LLM连接测试失败: ' + error.message, 'error');
+    } finally {
+        showSystemPrompt('');
+        hideLoading();
+    }
+}
+
+export async function testEmbeddingModel() {
+    showLoading('测试嵌入模型中...');
+    try {
+        const response = await fetch(`${state.API_BASE_URL}/test/embedding`, {
+            method: 'POST'
+        });
+        const result = await response.json();
+
+        if (result.success) {
+            showToast(`嵌入模型测试成功，维度: ${result.dimension}`, 'success');
+        } else {
+            showToast('嵌入模型测试失败: ' + result.message, 'error');
+        }
+    } catch (error) {
+        showToast('嵌入模型测试失败: ' + error.message, 'error');
+    } finally {
+        hideLoading();
+    }
+}

--- a/index.html
+++ b/index.html
@@ -934,6 +934,6 @@
         </div>
     </div>
 
-    <script src="script.js"></script>
+    <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/state.js
+++ b/state.js
@@ -1,0 +1,26 @@
+export default {
+    API_BASE_URL: 'http://localhost:8000',
+    currentConfig: {
+        llm: {
+            type: 'local',
+            url: 'https://v1.voct.top/v1',
+            model: 'gpt-4.1-mini',
+            key: 'EMPTY',
+            temperature: 0.3
+        },
+        embedding: {
+            type: 'local-api',
+            url: 'http://192.168.22.191:8000/v1',
+            key: 'EMPTY',
+            model: 'auto',
+            dimension: 4096
+        }
+    },
+    charts: {},
+    currentFiles: [],
+    generationInProgress: false,
+    modalListenersInitialized: false,
+    chatHistory: [],
+    availableKnowledgeTypes: [],
+    editingPromptIndex: null
+};

--- a/ui.js
+++ b/ui.js
@@ -1,0 +1,83 @@
+export function showToast(message, type = 'info') {
+    const toastContainer = document.getElementById('toast-container');
+    if (!toastContainer) return;
+
+    const toast = document.createElement('div');
+    toast.className = `toast ${type}`;
+
+    const icons = {
+        success: 'fas fa-check-circle',
+        error: 'fas fa-exclamation-circle',
+        warning: 'fas fa-exclamation-triangle',
+        info: 'fas fa-info-circle'
+    };
+
+    toast.innerHTML = `
+        <div style="display: flex; align-items: center; gap: 0.5rem;">
+            <i class="${icons[type] || icons.info}"></i>
+            <span>${message}</span>
+        </div>
+    `;
+
+    toastContainer.appendChild(toast);
+
+    setTimeout(() => {
+        if (toast.parentNode) {
+            toast.parentNode.removeChild(toast);
+        }
+    }, 5000);
+}
+
+export function showLoading(text = '处理中...') {
+    const loadingOverlay = document.getElementById('loading-overlay');
+    const loadingText = document.getElementById('loading-text');
+
+    if (loadingText) loadingText.textContent = text;
+    if (loadingOverlay) {
+        loadingOverlay.style.display = 'flex';
+        loadingOverlay.classList.add('active');
+    }
+}
+
+export function hideLoading() {
+    const loadingOverlay = document.getElementById('loading-overlay');
+    if (loadingOverlay) {
+        loadingOverlay.style.display = 'none';
+        loadingOverlay.classList.remove('active');
+    }
+}
+
+export function showSystemPrompt(text) {
+    const promptEl = document.getElementById('prompt-viewer');
+    if (promptEl) {
+        if (text) {
+            promptEl.style.display = 'block';
+            promptEl.textContent = text;
+            showThinkingIndicator();
+        } else {
+            promptEl.style.display = 'none';
+            promptEl.textContent = '';
+            hideThinkingIndicator();
+        }
+    }
+}
+
+export function showThinkingIndicator() {
+    let indicator = document.getElementById('thinking-indicator');
+    const container = document.getElementById('streaming-content');
+    if (!container) return;
+    if (!indicator) {
+        indicator = document.createElement('div');
+        indicator.id = 'thinking-indicator';
+        indicator.innerHTML = '思考中 <span class="spinner"></span>';
+        container.parentNode.insertBefore(indicator, container.nextSibling);
+    }
+    indicator.style.display = 'flex';
+}
+
+export function hideThinkingIndicator() {
+    const indicator = document.getElementById('thinking-indicator');
+    if (indicator) {
+        indicator.style.display = 'none';
+    }
+}


### PR DESCRIPTION
## Summary
- break out state management into `state.js`
- move UI helper utilities into `ui.js`
- extract backend requests to `api.js`
- load `script.js` as an ES module
- update existing script to use state module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683a5afddd408326a953c2f366f97ce3